### PR TITLE
chore(dependabot): use directory for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,7 @@
----
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directories:
-      - "**/*"
+    directory: "/"
     schedule:
       interval: "weekly"
     commit-message:


### PR DESCRIPTION
To prevent duplicated pull requests for the same dependency.
